### PR TITLE
t-tests for LMM via lmerTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Depends:
 Imports:
     binom,iterators,pbkrtest,plotrix,plyr,RLRsim,stringr,stats,methods,utils,graphics,grDevices
 Suggests:
-    testthat,knitr,rmarkdown
+    testthat,knitr,rmarkdown,lmerTest
 LazyData: true
 RoxygenNote: 5.0.1
 VignetteBuilder: knitr

--- a/R/testLibrary.R
+++ b/R/testLibrary.R
@@ -30,7 +30,10 @@
 #' \item{\code{z}:}{
 #'     Z-test for models fitted with \code{\link[lme4]{glmer}} (or \code{\link{glm}}),
 #'     using the p-value from \code{\link[=summary.merMod]{summary}}.}
-#' \item{\code{t}:}{T-test for models fitted with \code{\link{lm}}}
+#' \item{\code{t}:}{
+#'     T-test for models fitted with \code{\link{lm}}. Also available for mixed models
+#'     when \code{\link[lmerTest]{lmerTest}} is installed, using the p-value calculated
+#'     using the Satterthwaite approximation for the denominator degrees of freedom.}
 #' \item{\code{lr}:}{Likelihood ratio test, using \code{\link[=anova.merMod]{anova}}.}
 #' \item{\code{kr}:}{
 #'     Kenward-Roger test, using \code{\link[pbkrtest]{KRmodcomp}}.

--- a/man/tests.Rd
+++ b/man/tests.Rd
@@ -55,7 +55,10 @@ fitted with \code{\link[lme4]{lmer}}.
 \item{\code{z}:}{
     Z-test for models fitted with \code{\link[lme4]{glmer}} (or \code{\link{glm}}),
     using the p-value from \code{\link[=summary.merMod]{summary}}.}
-\item{\code{t}:}{T-test for models fitted with \code{\link{lm}}}
+\item{\code{t}:}{
+    T-test for models fitted with \code{\link{lm}}. Also available for mixed models
+    when \code{\link[lmerTest]{lmerTest}} is installed, using the p-value calculated
+    using the Satterthwaite approximation for the denominator degrees of freedom.}
 \item{\code{lr}:}{Likelihood ratio test, using \code{\link[=anova.merMod]{anova}}.}
 \item{\code{kr}:}{
     Kenward-Roger test, using \code{\link[pbkrtest]{KRmodcomp}}.

--- a/simr.Rproj
+++ b/simr.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
This adds support for t-tests on LMM coefficients via the package `lmerTest`. If an `lmerTest` model is passed, it's used directly, if an `lme4` model is passed and `lmerTest` is installed, a warning is issued and the model is typecast, otherwise an error is thrown.  The Satterthwaite correction for denominator degrees of freedom is used. 

Two possible improvements are supporting an option for KR ddf and the `anova()` as a possible test function. Supporting F-tests via `anova()` would be interesting compared to the existing KR tests and the proposed functionality via `car::Anova()` (#27) because the Satterthwaite correction is more accurate than the Chi-Square approximation but faster than KR. Supporting the KR correction via an option may be interesting for a better approximation on the t-test. Supporting these via a package option (instead of an argument to the function call) would allow keeping the existing function calls intact.