### PR TITLE
Preparing for new version of lmerTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: r
+sudo: false
 cache: packages
 
 r:
@@ -8,9 +9,11 @@ r:
 
 warnings_are_errors: true
 
-before_install:
-  Rscript -e 'update.packages(ask = FALSE)'
-  
+addons:
+  apt:
+    packages:
+      - libnlopt-dev
+
 r_github_packages:
   - jimhester/covr
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Power Analysis for Generalised Linear Mixed Models by Simulation
 Description: Calculate power for generalised linear mixed models, using
     simulation. Designed to work with models fit using the 'lme4' package.
     Described in Green and MacLeod, 2016 <doi:10.1111/2041-210X.12504>.
-Version: 1.0.3-2
+Version: 1.0.3-1
 Authors@R: c(
     person("Green", "Peter", role=c("aut", "cre"), email="simr.peter@gmail.com",
         comment=c(ORCID="0000-0002-0238-9852")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://github.com/pitakakariki/simr
 BugReports: https://github.com/pitakakariki/simr/issues
 License: GPL (>=2)
 Depends:
-    lme4
+    lme4 (>= 1.1-16)
 Imports:
     binom,iterators,pbkrtest,plotrix,plyr,RLRsim,stringr,stats,methods,utils,graphics,grDevices,car,MASS
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### simr 1.0.3
+
+ - update maintainer email address
+
 ### simr 1.0.2
 
  - `print`, `summary`, and `confint` methods for easier access to results

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+### sim 1.0.4
+
+ - bugfixes
+     - contrast attributes are no longer dropped by `extend`
+     - more bugfixes and unit tests for binomial responses
+     - warnings for non-uniform weights, which aren't supported yet
+
 ### simr 1.0.3
 
  - update maintainer email address
@@ -20,3 +27,4 @@
 ### simr 1.0.0
 
  - Initial CRAN release.
+ 

--- a/R/doSim.R
+++ b/R/doSim.R
@@ -40,9 +40,26 @@ doSim.merMod <- function(object, ...) {
 
     simData <- getData(object)
 
-    y <- simulate(formula(object)[-2], newparams=simParams, newdata=simData, family=family(object), ...)[[1]]
+    # check weights
+    w <- weights(object)
+    if(!is.null(w)) if(length(w) != nrow(simData)) {
 
-    freeze(y, object)
+        if(length(unique(w)) != 1) {
+
+            stop("Non-uniform weights are not supported yet.")
+
+        }else {
+
+            w <- rep(w[1], nrow(simData))
+        }
+    }
+
+    simulate(
+        formula(object),
+        newparams=simParams,
+        newdata=simData,
+        family=family(object),
+        weights=w, ...)[[1]]
 }
 
 #' @export

--- a/R/extend.R
+++ b/R/extend.R
@@ -85,25 +85,13 @@ extend.data.frame <- function(object, along, within, n, values) {
 
     # cleanup
     X$.simr_repl <- NULL
-    #rownames(X) <- seq_len(nrow(X))
 
-    ### Experimental contrast support
-
-    foundContrasts <- FALSE
-
+    # copy contrast attributes
     for(j in seq_along(X)) {
 
         C <- attr(object[[j]], "contrasts")
-
-        if(!is.null(C)) {
-
-            foundContrasts <- TRUE
-
-            contrasts(X[[j]]) <- C
-        }
+        if(!is.null(C)) contrasts(X[[j]]) <- C
     }
-
-    if(foundContrasts) warning("Support for contrasts is still experimental")
 
     return(X)
 
@@ -114,7 +102,15 @@ extend.default <- function(object, along, within, n, values) {
 
     # Sanity checks
 
-    if(missing(n) && missing(values)) stop('Extended values not specified.')
+    if(length(unique(weights(object))) > 1) {
+
+        warning("Non-uniform weights are not supported")
+    }
+
+    if(missing(n) && missing(values)) {
+
+        stop("Extended values not specified.")
+    }
 
     if(missing(within)) {
 

--- a/R/lm.r
+++ b/R/lm.r
@@ -1,1 +1,0 @@
-fixef.lm <- coef

--- a/R/lmerTest_utils.R
+++ b/R/lmerTest_utils.R
@@ -1,0 +1,70 @@
+lmerTest_anova <- function(object, ...) {
+    # Produce lmerTest-anova table for lmer-model fits (lme4 or lmerTest) with old
+    # as well as new lmerTest package.
+    # Standard method dispatch for all non-lmerMod objects.
+    pkg_version <- "2.0-37.9005"
+    if(!inherits(object, "lmerMod")) return(anova(object, ...)) # non-lmer objects
+    if(requireNamespace("lmerTest", quietly=TRUE) && packageVersion("lmerTest") < pkg_version) {
+        if(inherits(object, "merModLmerTest"))
+            return(lmerTest::anova(object, ...))  else # lmerTest object
+                return(lmerTest::anova(as(object, "merModLmerTest"), ...)) # lme4 object
+    }
+    if(requireNamespace("lmerTest", quietly=TRUE) && packageVersion("lmerTest") >= pkg_version) {
+        if(inherits(object, "lmerModLmerTest"))
+            return(anova(object, ...)) else # lmerTest object
+                return(anova(lmerTest::as_lmerModLmerTest(object), ...)) # lme4 object
+    }
+    return(anova(object, ...)) # *merModLmerTest objects and/or 'lmerTest' is not available
+}
+
+lmerTest_summary <- function(object, ...) {
+    # Produce lmerTest-summary for lmer-model fits (lme4 or lmerTest) with old
+    # as well as new lmerTest package.
+    # Standard method dispatch for all non-lmerMod objects.
+    pkg_version <- "2.0-37.9005"
+    if(!inherits(object, "lmerMod")) return(summary(object, ...)) # non-lmer objects
+    if(requireNamespace("lmerTest", quietly=TRUE) && packageVersion("lmerTest") < pkg_version) {
+        if(inherits(object, "merModLmerTest"))
+            return(lmerTest::summary(object, ...))  else # lmerTest object
+                return(lmerTest::summary(as(object, "merModLmerTest"), ...)) # lme4 object
+    }
+    if(requireNamespace("lmerTest", quietly=TRUE) && packageVersion("lmerTest") >= pkg_version) {
+        if(inherits(object, "lmerModLmerTest"))
+            return(summary(object, ...)) else # lmerTest object
+                return(summary(lmerTest::as_lmerModLmerTest(object), ...)) # lme4 object
+    }
+    return(summary(object, ...)) # *merModLmerTest objects and/or 'lmerTest' is not available
+}
+
+is_lmerTest_class <- function(object)
+    # Check if an object is of class merModLmerTest or lmerModLmerTest
+    # Bridges across versions of lmerTest
+    inherits(object, "merModLmerTest") || inherits(object, "lmerModLmerTest")
+
+
+# anova_lmerTest <- function(object, ...) {
+#     # Dispatch the right anova method across lmerTest versions
+#     if(is_lmerTest_class(object) && requireNamespace("lmerTest", quietly = TRUE)) {
+#         if(packageVersion("lmerTest") < "2.0.37.90012")
+#             return(lmerTest::anova(object, ...)) else return(anova(object, ...))
+#     } else if(inherits(object, "merMod") && requireNamespace("lmerTest", quietly = TRUE)) {
+#         if(packageVersion("lmerTest") < "2.0.37.90012")
+#             return(lmerTest::anova(as(object, "merModLmerTest"), ...)) else
+#                 return(anova(lmerTest::as_lmerModLmerTest(object), ...))
+#     } # Default:
+#     anova(object, ...)
+# }
+#
+# summary_lmerTest <- function(object, ...) {
+#     # Dispatch the right summary method across lmerTest versions
+#     if(is_lmerTest_class(object) && requireNamespace("lmerTest", quietly = TRUE)) {
+#         if(packageVersion("lmerTest") < "2.0.37.90012")
+#             return(lmerTest::summary(object, ...)) else return(summary(object, ...))
+#     } else if(inherits(object, "merMod") && requireNamespace("lmerTest", quietly = TRUE)) {
+#         if(packageVersion("lmerTest") < "2.0.37.90012")
+#             return(lmerTest::summary(as(object, "merModLmerTest"), ...)) else
+#                 return(summary(lmerTest::as_lmerModLmerTest(object), ...))
+#     } # Default:
+#     summary(object, ...)
+# }
+#

--- a/R/modify.R
+++ b/R/modify.R
@@ -20,7 +20,7 @@
 #' \code{sigma<-} will only change the residual standard deviation,
 #' whereas \code{scale<-} will affect both \code{sigma} and \code{VarCorr}.
 #'
-#' These function can be used to change the value of individual parameters, such as
+#' These functions can be used to change the value of individual parameters, such as
 #' a single fixed effect coefficient, using standard R subsetting commands.
 #'
 #' @examples

--- a/R/print.R
+++ b/R/print.R
@@ -65,7 +65,7 @@ print.powerCurve <- function(x, ...) {
   cat("by ", x$xlab, ":\n", sep="")
   for(i in seq_along(x$ps)) {
 
-    cat(sprintf("%7i: ", x$xval[i]))
+    cat(sprintf("%7s: ", x$xval[i]))
     printerval(x$ps[[i]], ...)
     cat(" -", x$ps[[i]]$nrow, "rows")
     cat("\n")

--- a/R/testLibrary.R
+++ b/R/testLibrary.R
@@ -406,10 +406,10 @@ ztest <- function(fit, xname) {
 
     xname <- removeSquiggle(xname)
 
-    if("merModLmerTest" %in% class(fit)){
+    if(is_lmerTest_class(fit)){
         # block costly ddf calculations for lmerTest fits since we're using
         # the asymptotic approximation anyway
-        a <- summary(fit,ddf="lme4")$coefficients
+        a <- summary(fit, ddf="lme4")$coefficients
     }else{
         a <- summary(fit)$coefficients
     }
@@ -430,15 +430,14 @@ ttest <- function(fit, xname) {
     xname <- removeSquiggle(xname)
 
     if(inherits(fit,"merMod")){
-      if(inherits(fit,"merModLmerTest")){
+        if(is_lmerTest_class(fit)){
         # we assume that lmerTest is present, if we have an object of class lmerTest
         # no typecast necessary here
-        a <- lmerTest::summary(fit)$coefficients
+        a <- lmerTest_summary(fit)$coefficients
       }else{
         if(requireNamespace("lmerTest",quietly = TRUE)){
           #warning(paste("Using",getSimrOption("lmerTestDdf"),"approximation from lmerTest (casting merMod to merModLmerTest)"))
-          fit <- as(fit,"merModLmerTest")
-          a <- lmerTest::summary(fit,ddf=getSimrOption("lmerTestDdf"))$coefficients
+          a <- lmerTest_summary(fit, ddf=getSimrOption("lmerTestDdf"))$coefficients
         }else{
           stop("t-tests for lmer-fitted models require the lmerTest package")
         }
@@ -491,15 +490,14 @@ anovatest <- function(fit,xname){
     xname <- removeSquiggle(xname)
 
     if(inherits(fit,"merMod")){
-        if(inherits(fit,"merModLmerTest")){
+        if(is_lmerTest_class(fit)){
             # we assume that lmerTest is present, if we have an object of class lmerTest
             # no typecast necessary here
-            a <- lmerTest::anova(fit,ddf=getSimrOption("lmerTestDdf"),type=getSimrOption("lmerTestType"))
+            a <- lmerTest_anova(fit, ddf=getSimrOption("lmerTestDdf"), type=getSimrOption("lmerTestType"))
         }else{
             if(requireNamespace("lmerTest",quietly = TRUE)){
                 #warning(paste("Using",getSimrOption("lmerTestDdf"),"approximation from lmerTest (casting merMod to merModLmerTest)"))
-                fit <- as(fit,"merModLmerTest")
-                a <- lmerTest::anova(fit,ddf=getSimrOption("lmerTestDdf"),type=getSimrOption("lmerTestType"))
+                a <- lmerTest_anova(fit, ddf=getSimrOption("lmerTestDdf"), type=getSimrOption("lmerTestType"))
             }else{
                 stop("anova-tests for lmer-fitted models require the lmerTest package")
             }
@@ -586,7 +584,7 @@ satest <- function(fit, xname) {
 
     xname <- removeSquiggle(xname)
 
-    a <- lmerTest::summary(as(fit, "merModLmerTest"), ddf="Satterthwait")$coefficients
+    a <- lmerTest_summary(fit, ddf="Satterthwait")$coefficients
 
     rval <- a[xname, "Pr(>|t|)"]
     return(rval)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # simr
 
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/pitakakariki/simr?branch=master&svg=true)](https://ci.appveyor.com/project/pitakakariki/simr)
-[![Build Status](https://travis-ci.org/pitakakariki/simr.svg?branch=master)](https://travis-ci.org/pitakakariki/simr)
-[![Coverage Status](https://codecov.io/gh/pitakakariki/simr/branch/master/graph/badge.svg)](https://codecov.io/github/pitakakariki/simr?branch=master)
-
 Power Analysis for Generalised Linear Mixed Models by Simulation.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # simr
 
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/pitakakariki/simr?branch=master&svg=true)](https://ci.appveyor.com/project/pitakakariki/simr)
+[![Build Status](https://travis-ci.org/pitakakariki/simr.svg?branch=master)](https://travis-ci.org/pitakakariki/simr)
+[![Coverage Status](https://codecov.io/gh/pitakakariki/simr/branch/master/graph/badge.svg)](https://codecov.io/github/pitakakariki/simr?branch=master)
+
 Power Analysis for Generalised Linear Mixed Models by Simulation.
 
 ## Getting Started

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -7,7 +7,6 @@
 \alias{VarCorr<-}
 \alias{sigma<-}
 \alias{scale<-}
-\alias{ranef<-}
 \title{Modifying model parameters.}
 \usage{
 fixef(object) <- value
@@ -41,7 +40,7 @@ leave \code{object} unchanged, as you would expect.
 \code{sigma<-} will only change the residual standard deviation,
 whereas \code{scale<-} will affect both \code{sigma} and \code{VarCorr}.
 
-These function can be used to change the value of individual parameters, such as
+These functions can be used to change the value of individual parameters, such as
 a single fixed effect coefficient, using standard R subsetting commands.
 }
 \examples{

--- a/tests/testthat/test_binomial.R
+++ b/tests/testthat/test_binomial.R
@@ -1,15 +1,23 @@
 context("Binomial")
 
-## Logical response
+## binary response
 
 zbin <- with(simdata, z < 3)
 glm_bin1 <- glm(zbin ~ x + g, family="binomial", data=simdata)
 glmm_bin1 <- glmer(zbin ~ x + (1|g), family="binomial", data=simdata)
 
-test_that("binomial with logical response works", {
+test_that("binomial with binary response works", {
 
-  temp <- doTest(doFit(doSim(glm_bin1), glm_bin1))
-  temp <- doTest(doFit(doSim(glmm_bin1), glmm_bin1))
+    y <- doSim(glm_bin1)
+    expect_true(all(y * (1-y) == 0))
+
+    temp <- doTest(doFit(doSim(glm_bin1), glm_bin1))
+
+
+    y <- doSim(glmm_bin1)
+    expect_true(all(y * (1-y) == 0))
+
+    temp <- doTest(doFit(doSim(glmm_bin1), glmm_bin1))
 
 })
 
@@ -20,8 +28,46 @@ glmm_bin2 <- glmer(cbind(z, 10-z) ~ x + (1|g), family="binomial", data=simdata)
 
 test_that("binomial with cbind response works", {
 
-  temp <- doTest(doFit(doSim(glm_bin2), glm_bin2))
-  temp <- doTest(doFit(doSim(glmm_bin2), glmm_bin2))
+    y <- doSim(glm_bin2)
+    expect_identical(dim(y), c(30L, 2L))
+
+    temp <- doTest(doFit(doSim(glm_bin2), glm_bin2))
+
+    y <- doSim(glmm_bin2)
+    expect_identical(dim(y), c(30L, 2L))
+
+    temp <- doTest(doFit(doSim(glmm_bin2), glmm_bin2))
+
+})
+
+## proportion response
+
+zweight <- rep(10, nrow(simdata))
+zprop <- with(simdata, z/zweight)
+
+glm_bin3 <- glm(zprop ~ x + g, family="binomial", data=simdata, weights=zweight)
+glmm_bin3 <- glmer(zprop ~ x + (1|g), family="binomial", data=simdata, weights=zweight)
+
+zweight_b <- zweight + c(0,1)
+zprop_b <- with(simdata, z/zweight_b)
+
+glmm_bin3b <- glmer(zprop_b ~ x + (1|g), family="binomial", data=simdata, weights=zweight_b)
+
+test_that("binomial with proportion response works", {
+
+    y <- doSim(glm_bin3)
+    expect_equal(zweight*y, round(zweight*y))
+    expect_true(!all(y %in% c(0, 1)))
+
+    temp <- doTest(doFit(doSim(glm_bin2), glm_bin2))
+
+    y <- doSim(glmm_bin3)
+    expect_equal(zweight*y, round(zweight*y))
+    expect_true(!all(y %in% c(0, 1)))
+
+    temp <- doTest(doFit(doSim(glmm_bin2), glmm_bin2))
+
+    expect_warning(xm_bin3 <- extend(glmm_bin3b, along="g", n=5), "not supported")
 
 })
 

--- a/tests/testthat/test_contrasts.R
+++ b/tests/testthat/test_contrasts.R
@@ -1,0 +1,20 @@
+context("Contrasts")
+
+set.seed(76)
+
+simdata_con <- within(simdata, {
+
+    f <- as.factor(sample(letters[1:3], nrow(simdata), TRUE))
+    contrasts(f) <- contr.sum(3)
+})
+
+fm_con <- lmer(y ~ f + (1|g), data=simdata_con)
+fixef(fm_con) <- fixef(fm_con)
+xm_con <- extend(fm_con, along="g", n=6)
+
+test_that("Contrasts work", {
+
+    temp <- powerSim(xm_con)
+
+    expect_equal(nrow(temp$errors), 0)
+})

--- a/tests/testthat/test_extend.r
+++ b/tests/testthat/test_extend.r
@@ -1,6 +1,6 @@
-context('extend')
+context("extend")
 
-test_that('extended model has correct dimensions', {
+test_that("extended model has correct dimensions", {
 
     x1 <- extend(fm1, along="x", n=20)
 
@@ -22,18 +22,10 @@ test_that('extended model has correct dimensions', {
     expect_equal(nrow(getData(x4)), 2*nrow(getData(flm)))
 })
 
-##
-## Add a lot more tests
-##
+test_that("extend works with a single column data frame", {
 
-# works for data.frame, lm, glm, lmer, glmer.
+    X5 <- data.frame(x=1:5)
+    X10 <- data.frame(x=1:10)
 
-# n, values, addn, addvalues
-
-# sorting
-
-# factors
-
-# each feature on checklist
-
-
+    expect_equivalent(extend(X5, along="x", n=10), X10)
+})

--- a/vignettes/fromscratch.Rmd
+++ b/vignettes/fromscratch.Rmd
@@ -22,8 +22,8 @@ simrOptions(nsim=100, progress=FALSE)
 First set up some covariates with `expand.grid`.
 
 ```{r}
-x <- rep(1:10)
-g <- c('a', 'b', 'c')
+x <- 1:10
+g <- letters[1:3]
 
 X <- expand.grid(x=x, g=g)
 ```


### PR DESCRIPTION
Hello,

When preparing an update of lmerTest we noticed that simr doesn't pass its checks with the new lmerTest. Please consider this pull request which makes simr work with both current/cran version as well as the upcoming version of lmerTest.

The new version of lmerTest is at https://github.com/runehaubo/lmerTestR. For further information about the new version of lmerTest, please see https://github.com/runehaubo/lmerTestR/blob/master/pkg_notes/new_lmerTest.pdf

Release plans for the new lmerTest are still a bit sketchy as other packages need updates as well, but I wanted to share this PR with you after having played around with simr+lmerTest.

Cheers
Rune
for the lmerTest developers