### PR TITLE
Use object rather than formula(object) in doSim

### DIFF
--- a/R/doSim.R
+++ b/R/doSim.R
@@ -60,7 +60,7 @@ doSim.merMod <- function(object, ...) {
     }
 
     simulate(
-        formula(object),
+        object,
         newparams=simParams,
         newdata=simData,
         family=family(object),


### PR DESCRIPTION
If control parameters are set in the `merMod` object (e.g., to disable checks when using workarounds to freely estimate residual variances across groups; cf. https://stats.stackexchange.com/questions/255546/test-homogeneity-in-lmer-models), using `formula(object)` loses these control parameters.

It doesn't appear to be possible to pass a `control` argument to `simulate`. Using `object` rather than `formula(object)` in `doSim.merMod` yields the same results, while also preserving any `control` arguments set in the original `object` model.