### PR TITLE
Added Satterthwaite (`'sa'`) description

### DIFF
--- a/man/tests.Rd
+++ b/man/tests.Rd
@@ -100,6 +100,10 @@ fitted with \code{\link[lme4]{lmer}}.
     Kenward-Roger test, using \code{\link[pbkrtest]{KRmodcomp}}.
     This only applies to models fitted with \code{\link[lme4]{lmer}}, and compares models with
     different fixed effect specifications but equivalent random effects.}
+\item{\code{sa}:}{
+    Satterthwaite test, using \code{\link[lmerTest]{summary}}.
+    This only applies to models fitted with \code{\link[lme4]{lmer}}. This method is faster
+    than \code{kr}, and almost equally precise (Luke, 2017).}
 \item{\code{pb}:}{
     Parametric bootstrap test, using \code{\link[pbkrtest]{PBmodcomp}}.
     This test will be very accurate, but is also very computationally expensive.}
@@ -120,4 +124,7 @@ rcompare(~ (1|g))(lm1)
 \references{
 Baayen, R. H., Davidson, D. J., and Bates, D. M. (2008). Mixed-effects modeling
 with crossed random effects for subjects and items. Journal of Memory and Language, 59, 390--412.
+  
+Luke, S. G. (2017). Evaluating significance in linear mixed-effects models in R. Behavior Research
+Methods, 49(4), 1494--1502.
 }


### PR DESCRIPTION
Added Satterthwaite (`'sa'`) description to tests.R

```
\item{\code{sa}:}{
    Satterthwaite test, using \code{\link[lmerTest]{summary}}.
    This only applies to models fitted with \code{\link[lme4]{lmer}}. This method is faster
    than \code{kr}, and almost equally precise (Luke, 2017).}
```
...

```
Luke, S. G. (2017). Evaluating significance in linear mixed-effects models in R. Behavior Research
Methods, 49(4), 1494--1502.
```