### PR TITLE
Small continuation to `sa` description

### DIFF
--- a/man/tests.Rd
+++ b/man/tests.Rd
@@ -50,8 +50,8 @@ Specify a statistical test to apply
 
 The \code{method} argument can be used to specify one of the following tests.
 Note that \code{"z"} is an asymptotic approximation for models not fitted
-with \code{\link[lme4]{glmer}} and \code{"kr"} will only work with models
-fitted with \code{\link[lme4]{lmer}}.
+with \code{\link[lme4]{glmer}}, and \code{"kr"} and \code{"sa"} will only work
+with models fitted with \code{\link[lme4]{lmer}}.
 
 \describe{
 \item{\code{z}:}{


### PR DESCRIPTION
Just added `and \code{"sa"}` in:

```
The \code{method} argument can be used to specify one of the following tests.
Note that \code{"z"} is an asymptotic approximation for models not fitted
with \code{\link[lme4]{glmer}}, and \code{"kr"} and \code{"sa"} will only work
with models fitted with \code{\link[lme4]{lmer}}.
```