### PR TITLE
Use rbind()+lapply() over plyr::ldply()

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -95,7 +95,7 @@ summary.powerSim <- function(object, alpha=object$alpha, level=0.95, method=getS
 #' @export
 summary.powerCurve <- function(object, alpha=object$alpha, level=0.95, method=getSimrOption("binom"), ...) {
 
-    rval <- ldply(object$ps, summary, alpha=alpha, level=level, method=method)
+    rval <- do.call(rbind, lapply(object$ps, summary, alpha=alpha, level=level, method=method))
     rval <- cbind(nrow=sapply(object$ps, `[[`, "nrow"), nlevels=object$nlevels, rval)
 
     class(rval) <- c("summary.powerCurve", class(rval))


### PR DESCRIPTION
Related to #300. This should be safe since the `ldply()` input is controlled by the object class, and the return structure of the `summary.powerSim` object is pretty clear --> we don't have to worry too much about edge case behavior.