### PR TITLE
switch to nAGQ=0 in makeGlmer to avoid parameter length mismatch

### DIFF
--- a/R/new.R
+++ b/R/new.R
@@ -39,7 +39,7 @@ makeMer <- function(formula, family, fixef, VarCorr, sigma, data, dataName) {
 
         } else {
 
-            rval <- glmer(formula, family=family, data=data, control=glmerSet(theta))
+            rval <- glmer(formula, family=family, data=data, control=glmerSet(theta), nAGQ=0)
             rval@call$family <- rval@resp$family$family
         }
     )


### PR DESCRIPTION
the development version of `lme4` has added a check on the length of the fitted/optimized parameter vector going to `mkMerMod` (the last modular step where we combine all the model structures with the optimization results to generate a `merMod` object). This breaks `makeGlmer`, which was only passing the `theta` (random-effect) parameters and not the `beta` (fixed-effect) parameters at this point. With Claude's assistance I tweaked the code to use `nAGQ=0`, which profiles out the fixed-effect parameters and thus ends up giving `mkMerMod` the number of parameters it was expecting.

We hope to update `lme4` on CRAN soon, so you would be asked to update `simr` soon after that &mdash; hope that's not too much of an inconvenience.